### PR TITLE
Fail push action if image tag not updated in YAML

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -36,6 +36,12 @@ jobs:
                   ENV_IMG_FILENAME="$(basename ${_IMG})-${_TAG}.tar"
                   EOF
 
+            - name: Verify action YAML references matching image tag
+              run: |
+                  source .env
+                  cat action.yml
+                  egrep -m 1 -q "^\s+image:\s+['\"]?docker://${ENV_FQIN}['\"]?$" action.yml
+
             - name: Build container image
               run: |
                   source .env

--- a/action.yml
+++ b/action.yml
@@ -11,4 +11,5 @@ runs:
     # environment variables are for communicating across runtime environments
     # env:
     using: 'docker'
-    image: 'docker://quay.io/cevich/makecontaineraction:v1.1'
+    # N/B: This must be the last line in this file for CI purposes (here)
+    image: 'docker://quay.io/cevich/makecontaineraction:v1.3'


### PR DESCRIPTION
Callers of the action get whatever image is specified in `action.yml`.
Since the push action (here) builds and uploads the image, the
tag of the image must always match the git and image tag.  Fail the
build if this is ever not the case.

Signed-off-by: Chris Evich <cevich@redhat.com>